### PR TITLE
Add Workflow.run! and Workflow.step

### DIFF
--- a/exe/manageiq-floe
+++ b/exe/manageiq-floe
@@ -13,7 +13,4 @@ end
 require "logger"
 ManageIQ::Floe.logger = Logger.new(STDOUT)
 
-workflow = ManageIQ::Floe::Workflow.load(opts[:workflow], opts[:inputs])
-
-state = workflow.first_state
-state, _outputs = state.run! until state.nil?
+ManageIQ::Floe::Workflow.load(opts[:workflow], "global" => opts[:inputs]).run!

--- a/lib/manageiq/floe/workflow.rb
+++ b/lib/manageiq/floe/workflow.rb
@@ -12,20 +12,57 @@ module ManageIQ
         end
       end
 
-      attr_reader :context, :first_state, :payload, :states, :states_by_name, :start_at
+      attr_reader :context, :payload, :states, :states_by_name, :current_state, :status
 
       def initialize(payload, context = {})
         payload = JSON.parse(payload) if payload.kind_of?(String)
         context = JSON.parse(context) if context.kind_of?(String)
 
-        @payload        = payload
-        @context        = context
+        @payload = payload
+        @context = context
+
         @states         = parse_states
-        @states_by_name = states.each_with_object({}) { |state, result| result[state.name] = state }
-        @start_at       = @payload["StartAt"]
-        @first_state    = @states_by_name[@start_at]
+        @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
+        start_at        = @payload["StartAt"]
+
+        @context["states"] ||= []
+        @context["current_state"] ||= start_at
+
+        current_state_name = @context["current_state"]
+        @current_state = @states_by_name[current_state_name]
+
+        @status = current_state_name == start_at ? "pending" : current_state.status
       rescue JSON::ParserError => err
         raise ManageIQ::Floe::InvalidWorkflowError, err.message
+      end
+
+      def step
+        @status = "running" if @status == "pending"
+
+        tick = Time.now.utc
+        next_state, outputs = current_state.run!
+        tock = Time.now.utc
+
+        @context["states"] << {"start" => tick, "end" => tock, "time" => tock - tick, "outputs" => outputs}
+
+        @status = current_state.status
+
+        next_state_name = next_state&.name
+        @context["current_state"] = next_state_name
+        @current_state = next_state_name && @states_by_name[next_state_name]
+
+        self
+      end
+
+      def run!
+        until end?
+          step
+        end
+        self
+      end
+
+      def end?
+        current_state.nil?
       end
 
       def to_dot

--- a/lib/manageiq/floe/workflow/state.rb
+++ b/lib/manageiq/floe/workflow/state.rb
@@ -35,6 +35,10 @@ module ManageIQ
           @end
         end
 
+        def status
+          end? ? "success" : "running"
+        end
+
         def run!
           logger.info("Running state: [#{name}]")
 

--- a/lib/manageiq/floe/workflow/states/choice.rb
+++ b/lib/manageiq/floe/workflow/states/choice.rb
@@ -17,9 +17,8 @@ module ManageIQ
           def run!
             logger.info("Running state: [#{name}]")
 
-            next_state_name = choices.map { |choice| ChoiceRule.build(choice, workflow.context) }.detect(&:true?)&.next || default
+            next_state_name = choices.map { |choice| ChoiceRule.build(choice, workflow.context["global"]) }.detect(&:true?)&.next || default
 
-            # TODO evaluate the choice, for now just pick the first
             next_state = workflow.states_by_name[next_state_name]
             results = {}
 

--- a/lib/manageiq/floe/workflow/states/fail.rb
+++ b/lib/manageiq/floe/workflow/states/fail.rb
@@ -18,6 +18,10 @@ module ManageIQ
             true
           end
 
+          def status
+            "errored"
+          end
+
           private def to_dot_attributes
             super.merge(:color => "red")
           end


### PR DESCRIPTION
This commit pushes executing a full workflow into the Workflow class. A notable change here is that the incoming context is not just the inputs, but the full context including "global", "states", and "current_state". This allows stepping, persisting the context, then resuming from that context.

@agrare I wanted to discuss this one first before merge, because it change the inputs and I didn't know if you had other thoughts on how this should be done.  In the future, I'm wondering if the incoming context should be a defined class instead of a raw Hash, since it's easy to start messing up the names.

Required for https://github.com/agrare/manageiq-providers-workflows/pull/1

