### PR TITLE
Add env var for kubernetes runner namespace

### DIFF
--- a/lib/manageiq/floe/workflow/runner/kubernetes.rb
+++ b/lib/manageiq/floe/workflow/runner/kubernetes.rb
@@ -11,7 +11,7 @@ module ManageIQ
             require "base64"
             require "yaml"
 
-            @namespace = "default"
+            @namespace = ENV.fetch("DOCKER_RUNNER_NAMESPACE", "default")
 
             super
           end


### PR DESCRIPTION
I'd like to have a better way of setting options which would work with cmdline flags when running with `exe/manageiq-floe` or set via an engine or initializer but for now this will work